### PR TITLE
fix: add last rimworld gravtech for VGE

### DIFF
--- a/1.6/Mods/vanillaexpanded.gravship/Patches/vanillaexpanded.gravship-patch.xml
+++ b/1.6/Mods/vanillaexpanded.gravship/Patches/vanillaexpanded.gravship-patch.xml
@@ -25,6 +25,14 @@
 				</value>
 			</li>
 			<li Class="PatchOperationAddModExtension">
+				<xpath>/Defs/ResearchProjectDef[defName="OrbitalTech"]</xpath>
+				<value>
+					<li Class="ResearchWhatever.ResearchWhateverExtansion">
+						<ignore>true</ignore>
+					</li>
+				</value>
+			</li>
+			<li Class="PatchOperationAddModExtension">
 				<xpath>/Defs/ResearchProjectDef[defName="VGE_GravshipWeaponry"]</xpath>
 				<value>
 					<li Class="ResearchWhatever.ResearchWhateverExtansion">


### PR DESCRIPTION
Hi, me again with VGE, I found out I forgot one last vanilla Rimworld gravtech, which is also patched by VGE. oops
fix for #3 